### PR TITLE
Rename to descriptive variables

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,9 +219,9 @@
                         <input type="text" id="ga" value="9.80665" class="constant_field numeric" autocomplete="off" size="9" /><br />
                     </div>
                     <div class="columns four omega" style="display: none">
-                        <input type="checkbox" class="float" id="bd_c" autocomplete="off" />
-                        <label class="constant_label" for="bd">Burst Diameter (m)</label><br />
-                        <input type="text" id="bd" class="constant_field numeric scrollable" data-step="0.2" disabled="disabled" value="7.86" autocomplete="off" /><br />
+                        <input type="checkbox" class="float" id="burst_diameter_c" autocomplete="off" />
+                        <label class="constant_label" for="burst_diameter">Burst Diameter (m)</label><br />
+                        <input type="text" id="burst_diameter" class="constant_field numeric scrollable" data-step="0.2" disabled="disabled" value="7.86" autocomplete="off" /><br />
                         <input type="checkbox" class="float" id="cd_c" autocomplete="off" />
                         <label class="constant_label" for="cd">Balloon Cd</label><br />
                         <input type="text" id="cd" class="constant_field numeric scrollable" data-step="0.05" data-max="1" disabled="disabled" value="0.3" autocomplete="off" /><br />

--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
                     <h4>Payload Mass (g)</h4>
                     <input type="text" id="payload_mass_g" class="input_field numeric scrollable" value="1000" data-step="5" tabindex="1"/>
                     <h4>Balloon Mass (g)</h4>
-                    <select class="input_field" id="mb" tabindex="2">
+                    <select class="input_field" id="balloon_model" tabindex="2">
                         <option value="k100">Kaymont - 100</option>
                         <option value="k150">Kaymont - 150</option>
                         <option value="k200">Kaymont - 200</option>

--- a/index.html
+++ b/index.html
@@ -222,9 +222,9 @@
                         <input type="checkbox" class="float" id="burst_diameter_c" autocomplete="off" />
                         <label class="constant_label" for="burst_diameter">Burst Diameter (m)</label><br />
                         <input type="text" id="burst_diameter" class="constant_field numeric scrollable" data-step="0.2" disabled="disabled" value="7.86" autocomplete="off" /><br />
-                        <input type="checkbox" class="float" id="cd_c" autocomplete="off" />
-                        <label class="constant_label" for="cd">Balloon Cd</label><br />
-                        <input type="text" id="cd" class="constant_field numeric scrollable" data-step="0.05" data-max="1" disabled="disabled" value="0.3" autocomplete="off" /><br />
+                        <input type="checkbox" class="float" id="drag_coeff_c" autocomplete="off" />
+                        <label class="constant_label" for="drag_coeff">Balloon Cd</label><br />
+                        <input type="text" id="drag_coeff" class="constant_field numeric scrollable" data-step="0.05" data-max="1" disabled="disabled" value="0.3" autocomplete="off" /><br />
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@
                 <div class="five columns alpha grey float second">
                     <div class="sign"></div>
                     <h4>Target Burst Altitude (m)</h4>
-                    <input type="text" id="tba" class="input_field numeric scrollable" data-step="100" tabindex="3"/>
+                    <input type="text" id="target_burst_altitude" class="input_field numeric scrollable" data-step="100" tabindex="3"/>
                     <h4>Target Ascent rate (m/s)</h4>
                     <input type="text" id="target_ascent_rate" class="input_field numeric scrollable" data-step="0.1" value="5.0" tabindex="4"/>
                 </div>

--- a/index.html
+++ b/index.html
@@ -181,7 +181,7 @@
                         <span class="output_label">Burst Altitude:</span>
                         <span class="output_data" id="burst_altitude">33000 m</span>
                         <span class="output_label">Ascent Rate:</span>
-                        <span class="output_data" id="ar">2.33 m/s</span>
+                        <span class="output_data" id="ascent_rate">2.33 m/s</span>
                     </div>
                     <div class="three columns offset-by-one">
                         <span class="output_label">Time to Burst:</span>

--- a/index.html
+++ b/index.html
@@ -185,7 +185,7 @@
                     </div>
                     <div class="three columns offset-by-one">
                         <span class="output_label">Time to Burst:</span>
-                        <span class="output_data" id="ttb">238 min</span>
+                        <span class="output_data" id="time_to_burst">238 min</span>
                         <span class="output_label">Neck Lift:</span>
                         <span class="output_data" id="nl">1733 g</span>
                     </div>

--- a/index.html
+++ b/index.html
@@ -191,9 +191,9 @@
                     </div>
                     <div class="three columns offset-by-one">
                         <span class="output_label">Volume:</span>
-                        <span class="output_data" id="lv_m3">2.66 m<sup>3</sup></span>
-                        <span class="output_label" id="lv_l" style="font-weight: bold;">2660 L</span>
-                        <span class="output_data" id="lv_cf">93.9 ft<sup>3</sup></span>
+                        <span class="output_data" id="launch_volume_m3">2.66 m<sup>3</sup></span>
+                        <span class="output_label" id="launch_volume_l" style="font-weight: bold;">2660 L</span>
+                        <span class="output_data" id="launch_volume_cf">93.9 ft<sup>3</sup></span>
                     </div>
                 </div>
                 <div class="thirteen columns alpha grey fourth closed">

--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
                     <h4>Target Burst Altitude (m)</h4>
                     <input type="text" id="tba" class="input_field numeric scrollable" data-step="100" tabindex="3"/>
                     <h4>Target Ascent rate (m/s)</h4>
-                    <input type="text" id="tar" class="input_field numeric scrollable" data-step="0.1" value="5.0" tabindex="4"/>
+                    <input type="text" id="target_ascent_rate" class="input_field numeric scrollable" data-step="0.1" value="5.0" tabindex="4"/>
                 </div>
                 <div class="thirteen columns alpha grey third">
                     <h4 id="result">Result</h4>

--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@
                         <span class="output_label">Time to Burst:</span>
                         <span class="output_data" id="time_to_burst">238 min</span>
                         <span class="output_label">Neck Lift:</span>
-                        <span class="output_data" id="nl">1733 g</span>
+                        <span class="output_data" id="neck_lift">1733 g</span>
                     </div>
                     <div class="three columns offset-by-one">
                         <span class="output_label">Volume:</span>

--- a/index.html
+++ b/index.html
@@ -215,8 +215,8 @@
                         <input type="text" id="rho_air" value="1.2050" class="constant_field numeric" autocomplete="off" size="9"/><br />
                         <label class="constant_label" for="adm">Air Density Model</label><br />
                         <input type="text" id="adm" value="7238.3" class="constant_field numeric" autocomplete="off" size="9"/><br />
-                        <label class="constant_label" for="ga">Gravitational<br />Acceleration (m/s<sup>2</sup>)</label><br />
-                        <input type="text" id="ga" value="9.80665" class="constant_field numeric" autocomplete="off" size="9" /><br />
+                        <label class="constant_label" for="gravity_accel">Gravitational<br />Acceleration (m/s<sup>2</sup>)</label><br />
+                        <input type="text" id="gravity_accel" value="9.80665" class="constant_field numeric" autocomplete="off" size="9" /><br />
                     </div>
                     <div class="columns four omega" style="display: none">
                         <input type="checkbox" class="float" id="burst_diameter_c" autocomplete="off" />

--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
                 <div class="five columns alpha grey float first">
                     <div class="sign"></div>
                     <h4>Payload Mass (g)</h4>
-                    <input type="text" id="mp" class="input_field numeric scrollable" value="1000" data-step="5" tabindex="1"/>
+                    <input type="text" id="payload_mass_g" class="input_field numeric scrollable" value="1000" data-step="5" tabindex="1"/>
                     <h4>Balloon Mass (g)</h4>
                     <select class="input_field" id="mb" tabindex="2">
                         <option value="k100">Kaymont - 100</option>

--- a/index.html
+++ b/index.html
@@ -211,8 +211,8 @@
                         <input type="text" id="rho_g" value="0.1786" class="constant_field" size="9" disabled="disabled"/><br />
                     </div>
                     <div class="columns four" style="display: none">
-                        <label class="constant_label" for="rho_a">Air Density (kg/m<sup>3</sup>)</label><br />
-                        <input type="text" id="rho_a" value="1.2050" class="constant_field numeric" autocomplete="off" size="9"/><br />
+                        <label class="constant_label" for="rho_air">Air Density (kg/m<sup>3</sup>)</label><br />
+                        <input type="text" id="rho_air" value="1.2050" class="constant_field numeric" autocomplete="off" size="9"/><br />
                         <label class="constant_label" for="adm">Air Density Model</label><br />
                         <input type="text" id="adm" value="7238.3" class="constant_field numeric" autocomplete="off" size="9"/><br />
                         <label class="constant_label" for="ga">Gravitational<br />Acceleration (m/s<sup>2</sup>)</label><br />

--- a/index.html
+++ b/index.html
@@ -179,7 +179,7 @@
                     <h4 id="result">Result</h4>
                     <div class="three columns offset-by-one">
                         <span class="output_label">Burst Altitude:</span>
-                        <span class="output_data" id="ba">33000 m</span>
+                        <span class="output_data" id="burst_altitude">33000 m</span>
                         <span class="output_label">Ascent Rate:</span>
                         <span class="output_data" id="ar">2.33 m/s</span>
                     </div>

--- a/index.html
+++ b/index.html
@@ -207,8 +207,8 @@
                             <option value="boc">BOC Balloon Gas</option>
                             <option value="custom">Custom</option>
                         </select><br />
-                        <label class="constant_label" for="rho_g">Gas Density (kg/m<sup>3</sup>)</label><br />
-                        <input type="text" id="rho_g" value="0.1786" class="constant_field" size="9" disabled="disabled"/><br />
+                        <label class="constant_label" for="rho_gas">Gas Density (kg/m<sup>3</sup>)</label><br />
+                        <input type="text" id="rho_gas" value="0.1786" class="constant_field" size="9" disabled="disabled"/><br />
                     </div>
                     <div class="columns four" style="display: none">
                         <label class="constant_label" for="rho_air">Air Density (kg/m<sup>3</sup>)</label><br />

--- a/js/calc.js
+++ b/js/calc.js
@@ -309,14 +309,10 @@ function calc_update() {
     balloon_mass = parseFloat(balloon_model.substr(1)) / 1000.0;
     payload_mass = payload_mass_g / 1000.0;
 
-    var ascent_rate = 0;
-    var burst_altitude = 0;
-    var time_to_burst = 0;
-    var neck_lift = 0;
     var launch_radius = 0;
     var launch_volume = 0;
 
-    // volume of sphere is 4/3 * pi * r^3
+    // assuming a sphere, so the volume is 4/3 * pi * r^3
     var burst_volume = (4.0/3.0) * Math.PI * Math.pow(burst_diameter / 2.0, 3);
 
     if(target_burst_altitude_set) {
@@ -347,13 +343,13 @@ function calc_update() {
     var launch_volume = (4.0/3.0) * Math.PI * Math.pow(launch_radius, 3);
     var density_difference = rho_air - rho_gas;
     var gross_lift = launch_volume * density_difference;
-    neck_lift = gross_lift - balloon_mass;
+    var neck_lift = gross_lift - balloon_mass;
     var total_mass = payload_mass + balloon_mass;
     var free_lift = (gross_lift - total_mass) * gravity_accel;
-    ascent_rate = Math.sqrt(free_lift / (0.5 * drag_coeff * launch_area * rho_air));
+    var ascent_rate = Math.sqrt(free_lift / (0.5 * drag_coeff * launch_area * rho_air));
     var volume_ratio = launch_volume / burst_volume;
-    burst_altitude = -(adm) * Math.log(volume_ratio);
-    time_to_burst = burst_altitude / ascent_rate;
+    var burst_altitude = -(adm) * Math.log(volume_ratio);
+    var time_to_burst = burst_altitude / ascent_rate;
 
     if(isNaN(ascent_rate)) {
         set_error('target_burst_altitude', "Altitude unreachable for this configuration.");

--- a/js/calc.js
+++ b/js/calc.js
@@ -77,17 +77,17 @@ function sanity_check_inputs(mb, mp, mp_set, target_ascent_rate, target_burst_al
 
 }
 
-function sanity_check_constants(rho_g, rho_air, adm, ga, burst_diameter, cd) {
+function sanity_check_constants(rho_gas, rho_air, adm, ga, burst_diameter, cd) {
     if(!rho_air || rho_air < 0) {
         set_error('rho_air',"You need to specify a valid air density. (0<Ad)");
         return 1;
     }
-    if(!rho_g || rho_g < 0) {
-        set_error('rho_g',"You need to specify a valid gas density. (0<Gd)");
+    if(!rho_gas || rho_gas < 0) {
+        set_error('rho_gas',"You need to specify a valid gas density. (0<Gd)");
         return 1;
     }
-    if(rho_g > rho_air) {
-        set_error('rho_g',"Air density is less the gas density.");
+    if(rho_gas > rho_air) {
+        set_error('rho_gas',"Air density is less the gas density.");
         return 1;
     }
     if(!adm || adm < 0) {
@@ -110,38 +110,38 @@ function sanity_check_constants(rho_g, rho_air, adm, ga, burst_diameter, cd) {
     return 0;
 }
 
-function find_rho_g() {
+function find_rho_gas() {
     var gas = document.getElementById('gas').value;
-    var rho_g;
+    var rho_gas;
 
     switch(gas) {
         case 'he':
-            rho_g = 0.1786;
-            document.getElementById('rho_g').value = rho_g;
-            document.getElementById('rho_g').disabled = "disabled";
+            rho_gas = 0.1786;
+            document.getElementById('rho_gas').value = rho_gas;
+            document.getElementById('rho_gas').disabled = "disabled";
             break;
         case 'h':
-            rho_g = 0.0899;
-            document.getElementById('rho_g').value = rho_g;
-            document.getElementById('rho_g').disabled = "disabled";
+            rho_gas = 0.0899;
+            document.getElementById('rho_gas').value = rho_gas;
+            document.getElementById('rho_gas').disabled = "disabled";
             break;
         case 'ch4':
-            rho_g = 0.6672;
-            document.getElementById('rho_g').value = rho_g;
-            document.getElementById('rho_g').disabled = "disabled";
+            rho_gas = 0.6672;
+            document.getElementById('rho_gas').value = rho_gas;
+            document.getElementById('rho_gas').disabled = "disabled";
             break;
         case 'boc':
-            rho_g = 0.21076;
-            document.getElementById('rho_g').value = rho_g;
-            document.getElementById('rho_g').disabled = "disabled";
+            rho_gas = 0.21076;
+            document.getElementById('rho_gas').value = rho_gas;
+            document.getElementById('rho_gas').disabled = "disabled";
             break;
         default:
-            document.getElementById('rho_g').disabled = "";
-            rho_g = get_value('rho_g');
+            document.getElementById('rho_gas').disabled = "";
+            rho_gas = get_value('rho_gas');
             break;
     }
 
-    return rho_g;
+    return rho_gas;
 }
 
 function find_burst_diameter(mb) {
@@ -294,14 +294,14 @@ function calc_update() {
         return;
 
     // Get constants and check them
-    var rho_g = find_rho_g();
+    var rho_gas = find_rho_gas();
     var rho_air = get_value('rho_air');
     var adm = get_value('adm');
     var ga = get_value('ga');
     var burst_diameter = find_burst_diameter(mb);
     var cd = find_cd(mb);
 
-    if(sanity_check_constants(rho_g, rho_air, adm, ga, burst_diameter, cd))
+    if(sanity_check_constants(rho_gas, rho_air, adm, ga, burst_diameter, cd))
         return;
 
     // Do some maths
@@ -321,7 +321,7 @@ function calc_update() {
         launch_volume = burst_volume * Math.exp((-target_burst_altitude) / adm);
         launch_radius = Math.pow((3*launch_volume)/(4*Math.PI), (1/3));
     } else if(target_ascent_rate_set) {
-        var a = ga * (rho_air - rho_g) * (4.0 / 3.0) * Math.PI;
+        var a = ga * (rho_air - rho_gas) * (4.0 / 3.0) * Math.PI;
         var b = -0.5 * Math.pow(target_ascent_rate, 2) * cd * rho_air * Math.PI;
         var c = 0;
         var d = - (mp + mb) * ga;
@@ -343,7 +343,7 @@ function calc_update() {
 
     var launch_area = Math.PI * Math.pow(launch_radius, 2);
     var launch_volume = (4.0/3.0) * Math.PI * Math.pow(launch_radius, 3);
-    var density_difference = rho_air - rho_g;
+    var density_difference = rho_air - rho_gas;
     var gross_lift = launch_volume * density_difference;
     neck_lift = (gross_lift - mb) * 1000;
     var total_mass = mp + mb;
@@ -501,7 +501,7 @@ $(document).ready(function() {
     });
 
     // calculate result on change
-    var ids = ['mb', 'mp', 'target_ascent_rate', 'target_burst_altitude', 'gas', 'rho_g', 'rho_air', 'adm', 'burst_diameter', 'cd', 'burst_diameter_c', 'cd_c', 'ga'];
+    var ids = ['mb', 'mp', 'target_ascent_rate', 'target_burst_altitude', 'gas', 'rho_gas', 'rho_air', 'adm', 'burst_diameter', 'cd', 'burst_diameter_c', 'cd_c', 'ga'];
 
     $('#' + ids.join(", #")).bind('keyup change',function() {
         calc_update();

--- a/js/calc.js
+++ b/js/calc.js
@@ -353,7 +353,7 @@ function calc_update() {
     ascent_rate = Math.sqrt(free_lift / (0.5 * drag_coeff * launch_area * rho_air));
     var volume_ratio = launch_volume / burst_volume;
     burst_altitude = -(adm) * Math.log(volume_ratio);
-    time_to_burst = (burst_altitude / ascent_rate) / 60.0;
+    time_to_burst = burst_altitude / ascent_rate;
 
     if(isNaN(ascent_rate)) {
         set_error('target_burst_altitude', "Altitude unreachable for this configuration.");
@@ -372,7 +372,7 @@ function calc_update() {
 
     ascent_rate = ascent_rate.toFixed(2);
     burst_altitude = burst_altitude.toFixed();
-    time_to_burst = time_to_burst.toFixed();
+    time_to_burst_minutes = (time_to_burst / 60.0).toFixed();
     neck_lift = neck_lift.toFixed();
     launch_litres = (launch_volume * 1000).toFixed();
     launch_cf = (launch_volume * 35.31).toFixed(1);
@@ -380,7 +380,7 @@ function calc_update() {
 
     document.getElementById('ascent_rate').innerHTML = ascent_rate + " m/s";
     document.getElementById('burst_altitude').innerHTML = burst_altitude + " m";
-    document.getElementById('ttb').innerHTML = time_to_burst + " min";
+    document.getElementById('time_to_burst').innerHTML = time_to_burst_minutes + " min";
     document.getElementById('nl').innerHTML = neck_lift + " g";
     document.getElementById('lv_m3').innerHTML = launch_volume + " m<sup>3</sup>";
     document.getElementById('lv_l').innerHTML = launch_litres + " L";

--- a/js/calc.js
+++ b/js/calc.js
@@ -77,7 +77,7 @@ function sanity_check_inputs(mb, mp, mp_set, target_ascent_rate, target_burst_al
 
 }
 
-function sanity_check_constants(rho_gas, rho_air, adm, ga, burst_diameter, cd) {
+function sanity_check_constants(rho_gas, rho_air, adm, gravity_accel, burst_diameter, cd) {
     if(!rho_air || rho_air < 0) {
         set_error('rho_air',"You need to specify a valid air density. (0<Ad)");
         return 1;
@@ -94,8 +94,8 @@ function sanity_check_constants(rho_gas, rho_air, adm, ga, burst_diameter, cd) {
         set_error('adm',"You need to specify a valid air density model. (0<Adm)");
         return 1;
     }
-    if(!ga || ga <= 0) {
-        set_error('ga',"You need to specify a valid gravitational acceleration. (0<Ga)");
+    if(!gravity_accel || gravity_accel <= 0) {
+        set_error('gravity_accel',"You need to specify a valid gravitational acceleration. (0<Ga)");
         return 1;
     }
     if(!cd || cd < 0 || cd > 1) {
@@ -297,11 +297,11 @@ function calc_update() {
     var rho_gas = find_rho_gas();
     var rho_air = get_value('rho_air');
     var adm = get_value('adm');
-    var ga = get_value('ga');
+    var gravity_accel = get_value('gravity_accel');
     var burst_diameter = find_burst_diameter(mb);
     var cd = find_cd(mb);
 
-    if(sanity_check_constants(rho_gas, rho_air, adm, ga, burst_diameter, cd))
+    if(sanity_check_constants(rho_gas, rho_air, adm, gravity_accel, burst_diameter, cd))
         return;
 
     // Do some maths
@@ -321,10 +321,10 @@ function calc_update() {
         launch_volume = burst_volume * Math.exp((-target_burst_altitude) / adm);
         launch_radius = Math.pow((3*launch_volume)/(4*Math.PI), (1/3));
     } else if(target_ascent_rate_set) {
-        var a = ga * (rho_air - rho_gas) * (4.0 / 3.0) * Math.PI;
+        var a = gravity_accel * (rho_air - rho_gas) * (4.0 / 3.0) * Math.PI;
         var b = -0.5 * Math.pow(target_ascent_rate, 2) * cd * rho_air * Math.PI;
         var c = 0;
-        var d = - (mp + mb) * ga;
+        var d = - (mp + mb) * gravity_accel;
 
         var f = (((3*c)/a) - (Math.pow(b, 2) / Math.pow(a,2)) / 3.0);
         var g = (((2*Math.pow(b,3))/Math.pow(a,3)) -
@@ -347,7 +347,7 @@ function calc_update() {
     var gross_lift = launch_volume * density_difference;
     neck_lift = (gross_lift - mb) * 1000;
     var total_mass = mp + mb;
-    var free_lift = (gross_lift - total_mass) * ga;
+    var free_lift = (gross_lift - total_mass) * gravity_accel;
     ascent_rate = Math.sqrt(free_lift / (0.5 * cd * launch_area * rho_air));
     var volume_ratio = launch_volume / burst_volume;
     burst_altitude = -(adm) * Math.log(volume_ratio);
@@ -501,7 +501,7 @@ $(document).ready(function() {
     });
 
     // calculate result on change
-    var ids = ['mb', 'mp', 'target_ascent_rate', 'target_burst_altitude', 'gas', 'rho_gas', 'rho_air', 'adm', 'burst_diameter', 'cd', 'burst_diameter_c', 'cd_c', 'ga'];
+    var ids = ['mb', 'mp', 'target_ascent_rate', 'target_burst_altitude', 'gas', 'rho_gas', 'rho_air', 'adm', 'burst_diameter', 'cd', 'burst_diameter_c', 'cd_c', 'gravity_accel'];
 
     $('#' + ids.join(", #")).bind('keyup change',function() {
         calc_update();

--- a/js/calc.js
+++ b/js/calc.js
@@ -378,7 +378,7 @@ function calc_update() {
     launch_cf = (launch_volume * 35.31).toFixed(1);
     launch_volume = launch_volume.toFixed(2);
 
-    document.getElementById('ar').innerHTML = ascent_rate + " m/s";
+    document.getElementById('ascent_rate').innerHTML = ascent_rate + " m/s";
     document.getElementById('burst_altitude').innerHTML = burst_altitude + " m";
     document.getElementById('ttb').innerHTML = time_to_burst + " min";
     document.getElementById('nl').innerHTML = neck_lift + " g";

--- a/js/calc.js
+++ b/js/calc.js
@@ -316,6 +316,7 @@ function calc_update() {
     var launch_radius = 0;
     var launch_volume = 0;
 
+    // volume of sphere is 4/3 * pi * r^3
     var burst_volume = (4.0/3.0) * Math.PI * Math.pow(burst_diameter / 2.0, 3);
 
     if(target_burst_altitude_set) {
@@ -378,7 +379,7 @@ function calc_update() {
     launch_volume = launch_volume.toFixed(2);
 
     document.getElementById('ar').innerHTML = ascent_rate + " m/s";
-    document.getElementById('ba').innerHTML = burst_altitude + " m";
+    document.getElementById('burst_altitude').innerHTML = burst_altitude + " m";
     document.getElementById('ttb').innerHTML = time_to_burst + " min";
     document.getElementById('nl').innerHTML = neck_lift + " g";
     document.getElementById('lv_m3').innerHTML = launch_volume + " m<sup>3</sup>";

--- a/js/calc.js
+++ b/js/calc.js
@@ -347,7 +347,7 @@ function calc_update() {
     var launch_volume = (4.0/3.0) * Math.PI * Math.pow(launch_radius, 3);
     var density_difference = rho_air - rho_gas;
     var gross_lift = launch_volume * density_difference;
-    neck_lift = (gross_lift - balloon_mass) * 1000;
+    neck_lift = gross_lift - balloon_mass;
     var total_mass = payload_mass + balloon_mass;
     var free_lift = (gross_lift - total_mass) * gravity_accel;
     ascent_rate = Math.sqrt(free_lift / (0.5 * drag_coeff * launch_area * rho_air));
@@ -373,7 +373,7 @@ function calc_update() {
     ascent_rate = ascent_rate.toFixed(2);
     burst_altitude = burst_altitude.toFixed();
     time_to_burst_minutes = (time_to_burst / 60.0).toFixed();
-    neck_lift = neck_lift.toFixed();
+    neck_lift_g = (neck_lift * 1000.0).toFixed();
     launch_litres = (launch_volume * 1000).toFixed();
     launch_cf = (launch_volume * 35.31).toFixed(1);
     launch_volume = launch_volume.toFixed(2);
@@ -381,7 +381,7 @@ function calc_update() {
     document.getElementById('ascent_rate').innerHTML = ascent_rate + " m/s";
     document.getElementById('burst_altitude').innerHTML = burst_altitude + " m";
     document.getElementById('time_to_burst').innerHTML = time_to_burst_minutes + " min";
-    document.getElementById('nl').innerHTML = neck_lift + " g";
+    document.getElementById('neck_lift').innerHTML = neck_lift_g + " g";
     document.getElementById('lv_m3').innerHTML = launch_volume + " m<sup>3</sup>";
     document.getElementById('lv_l').innerHTML = launch_litres + " L";
     document.getElementById('lv_cf').innerHTML = launch_cf + " ft<sup>3</sup>";

--- a/js/calc.js
+++ b/js/calc.js
@@ -77,7 +77,7 @@ function sanity_check_inputs(mb, mp, mp_set, target_ascent_rate, target_burst_al
 
 }
 
-function sanity_check_constants(rho_g, rho_a, adm, ga, bd, cd) {
+function sanity_check_constants(rho_g, rho_a, adm, ga, burst_diameter, cd) {
     if(!rho_a || rho_a < 0) {
         set_error('rho_a',"You need to specify a valid air density. (0<Ad)");
         return 1;
@@ -102,8 +102,8 @@ function sanity_check_constants(rho_g, rho_a, adm, ga, bd, cd) {
         set_error('cd',"You need to specify a valid drag coefficient. (0≤Cd≤1)");
         return 1;
     }
-    if(!bd || bd <= 0) {
-        set_error('bd',"You need to specify a valid burst diameter. (0<Bd)");
+    if(!burst_diameter || burst_diameter <= 0) {
+        set_error('burst_diameter',"You need to specify a valid burst diameter. (0<Bd)");
         return 1;
     }
 
@@ -144,68 +144,68 @@ function find_rho_g() {
     return rho_g;
 }
 
-function find_bd(mb) {
-    var bds = new Array();
+function find_burst_diameter(mb) {
+    var burst_diameters = new Array();
 
     // From Kaymont Totex Sounding Balloon Data
-    bds["k50"] = 0.88;
-    bds["k100"] = 1.96;
-    bds["k150"] = 2.52;
-    bds["k200"] = 3.00;
-    bds["k300"] = 3.78;
-    bds["k350"] = 4.12;
-   //bds["k450"] = 4.72; // Discontinued?
-   //bds["k500"] = 4.99; // Discontinued?
-    bds["k600"] = 6.02;
-    //bds["k700"] = 6.53; // Discontinued?
-    bds["k800"] = 7.00;
-    bds["k1000"] = 7.86;
-    bds["k1200"] = 8.63;
-    bds["k1500"] = 9.44;
-    bds["k1600"] = 9.71;
-    bds["k1800"] = 9.98;
-    bds["k2000"] = 10.54;
-    bds["k3000"] = 13.00;
-    bds["k4000"] = 15.06;
+    burst_diameters["k50"] = 0.88;
+    burst_diameters["k100"] = 1.96;
+    burst_diameters["k150"] = 2.52;
+    burst_diameters["k200"] = 3.00;
+    burst_diameters["k300"] = 3.78;
+    burst_diameters["k350"] = 4.12;
+    //burst_diameters["k450"] = 4.72; // Discontinued?
+    //burst_diameters["k500"] = 4.99; // Discontinued?
+    burst_diameters["k600"] = 6.02;
+    //burst_diameters["k700"] = 6.53; // Discontinued?
+    burst_diameters["k800"] = 7.00;
+    burst_diameters["k1000"] = 7.86;
+    burst_diameters["k1200"] = 8.63;
+    burst_diameters["k1500"] = 9.44;
+    burst_diameters["k1600"] = 9.71;
+    burst_diameters["k1800"] = 9.98;
+    burst_diameters["k2000"] = 10.54;
+    burst_diameters["k3000"] = 13.00;
+    burst_diameters["k4000"] = 15.06;
     // 100g Hwoyee Data from http://www.hwoyee.com/images.aspx?fatherId=11010101&msId=1101010101&title=0
-    bds["h100"] = 2.00;
+    burst_diameters["h100"] = 2.00;
     // Hwoyee data from http://www.hwoyee.com/base.asp?ScClassid=521&id=521102
     // Updated 2024-11 from https://www.hwoyee.com/weather-balloon-meteorological-balloon-for-weather-sounding-wind-or-cloud-detection-near-space-researchesgiant-round-balloons-huge-balloons-product/
-    bds["h200"] = 2.97;
-    bds["h300"] = 4.30;
-    bds["h350"] = 4.80;
-    bds["h500"] = 5.80;
-    bds["h600"] = 6.50;
-    bds["h750"] = 6.90;
-    bds["h800"] = 7.00;
-    bds["h1000"] = 8.00;
-    bds["h1200"] = 9.10;
-    bds["h1600"] = 10.00;
+    burst_diameters["h200"] = 2.97;
+    burst_diameters["h300"] = 4.30;
+    burst_diameters["h350"] = 4.80;
+    burst_diameters["h500"] = 5.80;
+    burst_diameters["h600"] = 6.50;
+    burst_diameters["h750"] = 6.90;
+    burst_diameters["h800"] = 7.00;
+    burst_diameters["h1000"] = 8.00;
+    burst_diameters["h1200"] = 9.10;
+    burst_diameters["h1600"] = 10.00;
     // These two are fudged a little
-    bds["h2000"] = 11.00;
-    bds["h3000"] = 12.00;
+    burst_diameters["h2000"] = 11.00;
+    burst_diameters["h3000"] = 12.00;
     // PAWAN data from
     // http://randomaerospace.com/Random_Aerospace/Balloons.html
-    bds["p100"] = 1.6;
-    bds["p350"] = 4.0;
-    bds["p600"] = 5.8;
-    bds["p800"] = 6.6;
-    bds["p900"] = 7.0;
-    bds["p1200"] = 8.0;
-    bds["p1600"] = 9.5;
-    bds["p2000"] = 10.2;
+    burst_diameters["p100"] = 1.6;
+    burst_diameters["p350"] = 4.0;
+    burst_diameters["p600"] = 5.8;
+    burst_diameters["p800"] = 6.6;
+    burst_diameters["p900"] = 7.0;
+    burst_diameters["p1200"] = 8.0;
+    burst_diameters["p1600"] = 9.5;
+    burst_diameters["p2000"] = 10.2;
 
-    var bd;
+    var burst_diameter;
 
-    if($('#bd_c:checked').length){
-        bd = get_value('bd');
+    if($('#burst_diameter_c:checked').length){
+        burst_diameter = get_value('burst_diameter');
     } else {
-        bd = bds[$('#mb').val()];
-        // Write data back into bd field.
-        $('#bd').val(bd.toFixed(2));
+        burst_diameter = burst_diameters[$('#mb').val()];
+        // Write data back into burst_diameter field.
+        $('#burst_diameter').val(burst_diameter.toFixed(2));
     }
 
-    return bd;
+    return burst_diameter;
 }
 
 function find_cd(mb) {
@@ -298,10 +298,10 @@ function calc_update() {
     var rho_a = get_value('rho_a');
     var adm = get_value('adm');
     var ga = get_value('ga');
-    var bd = find_bd(mb);
+    var burst_diameter = find_burst_diameter(mb);
     var cd = find_cd(mb);
 
-    if(sanity_check_constants(rho_g, rho_a, adm, ga, bd, cd))
+    if(sanity_check_constants(rho_g, rho_a, adm, ga, burst_diameter, cd))
         return;
 
     // Do some maths
@@ -315,7 +315,7 @@ function calc_update() {
     var launch_radius = 0;
     var launch_volume = 0;
 
-    var burst_volume = (4.0/3.0) * Math.PI * Math.pow(bd / 2.0, 3);
+    var burst_volume = (4.0/3.0) * Math.PI * Math.pow(burst_diameter / 2.0, 3);
 
     if(target_burst_altitude_set) {
         launch_volume = burst_volume * Math.exp((-target_burst_altitude) / adm);
@@ -363,7 +363,7 @@ function calc_update() {
     }
 
     // Note - this warning will override the regulatory warning above.
-    if(bd >= 10 && ascent_rate < 4.8) {
+    if(burst_diameter >= 10 && ascent_rate < 4.8) {
         set_warning('floater', "Configuration suggests a possible floater");
     }
 
@@ -492,16 +492,16 @@ $(document).ready(function() {
     });
 
     // enable disabled constants
-    $('#bd_c, #cd_c').click(function() {
-        if($('#bd_c:checked').length) $('#bd').removeAttr('disabled');
-        else $('#bd').attr('disabled', 'disabled');
+    $('#burst_diameter_c, #cd_c').click(function() {
+        if($('#burst_diameter_c:checked').length) $('#burst_diameter').removeAttr('disabled');
+        else $('#burst_diameter').attr('disabled', 'disabled');
 
         if($('#cd_c:checked').length) $('#cd').removeAttr('disabled');
         else $('#cd').attr('disabled', 'disabled');
     });
 
     // calculate result on change
-    var ids = ['mb', 'mp', 'target_ascent_rate', 'target_burst_altitude', 'gas', 'rho_g', 'rho_a', 'adm', 'bd', 'cd', 'bd_c', 'cd_c', 'ga'];
+    var ids = ['mb', 'mp', 'target_ascent_rate', 'target_burst_altitude', 'gas', 'rho_g', 'rho_a', 'adm', 'burst_diameter', 'cd', 'burst_diameter_c', 'cd_c', 'ga'];
 
     $('#' + ids.join(", #")).bind('keyup change',function() {
         calc_update();

--- a/js/calc.js
+++ b/js/calc.js
@@ -34,14 +34,14 @@ function set_warning(id, text) {
     text = "Result (" + text + ")";
     $("#result").addClass('warning').text(text);
 }
-function sanity_check_inputs(mb, mp, mp_set, target_ascent_rate, tba, target_ascent_rate_set, tba_set) {
-    if(target_ascent_rate_set && tba_set) {
+function sanity_check_inputs(mb, mp, mp_set, target_ascent_rate, target_burst_altitude, target_ascent_rate_set, target_burst_altitude_set) {
+    if(target_ascent_rate_set && target_burst_altitude_set) {
         set_error('target_ascent_rate', "Specify either target burst altitude or target ascent rate!");
-        set_error('tba', "Specify either target burst altitude or target ascent rate!");
+        set_error('target_burst_altitude', "Specify either target burst altitude or target ascent rate!");
         return 1;
-    } else if(!target_ascent_rate_set && !tba_set) {
+    } else if(!target_ascent_rate_set && !target_burst_altitude_set) {
         set_error('target_ascent_rate', "Must specify at least one target!");
-        set_error('tba', "Must specify at least one target!");
+        set_error('target_burst_altitude', "Must specify at least one target!");
         return 1;
     }
 
@@ -53,11 +53,11 @@ function sanity_check_inputs(mb, mp, mp_set, target_ascent_rate, tba, target_asc
         return 1;
     }
 
-    if(tba_set && tba < 10000) {
-        set_error('tba', "Target burst altitude is too low! (less than 10km)");
+    if(target_burst_altitude_set && target_burst_altitude < 10000) {
+        set_error('target_burst_altitude', "Target burst altitude is too low! (less than 10km)");
         return 1;
-    } else if(tba_set && tba > 40000) {
-        set_error('tba',
+    } else if(target_burst_altitude_set && target_burst_altitude > 40000) {
+        set_error('target_burst_altitude',
             "Target burst altitude is too high! (greater than 40km)");
         return 1;
     }
@@ -278,19 +278,19 @@ function calc_update() {
     var mb = document.getElementById('mb').value;
     var mp = get_value('mp');
     var target_ascent_rate = get_value('target_ascent_rate');
-    var tba = get_value('tba');
+    var target_burst_altitude = get_value('target_burst_altitude');
     var mp_set = 0;
     var target_ascent_rate_set = 0;
-    var tba_set = 0;
+    var target_burst_altitude_set = 0;
 
     if(document.getElementById('mp').value)
         mp_set = 1;
     if(document.getElementById('target_ascent_rate').value)
         target_ascent_rate_set = 1;
-    if(document.getElementById('tba').value)
-        tba_set = 1;
+    if(document.getElementById('target_burst_altitude').value)
+        target_burst_altitude_set = 1;
 
-    if(sanity_check_inputs(mb, mp, mp_set, target_ascent_rate, tba, target_ascent_rate_set, tba_set))
+    if(sanity_check_inputs(mb, mp, mp_set, target_ascent_rate, target_burst_altitude, target_ascent_rate_set, target_burst_altitude_set))
         return;
 
     // Get constants and check them
@@ -317,8 +317,8 @@ function calc_update() {
 
     var burst_volume = (4.0/3.0) * Math.PI * Math.pow(bd / 2.0, 3);
 
-    if(tba_set) {
-        launch_volume = burst_volume * Math.exp((-tba) / adm);
+    if(target_burst_altitude_set) {
+        launch_volume = burst_volume * Math.exp((-target_burst_altitude) / adm);
         launch_radius = Math.pow((3*launch_volume)/(4*Math.PI), (1/3));
     } else if(target_ascent_rate_set) {
         var a = ga * (rho_a - rho_g) * (4.0 / 3.0) * Math.PI;
@@ -354,7 +354,7 @@ function calc_update() {
     time_to_burst = (burst_altitude / ascent_rate) / 60.0;
 
     if(isNaN(ascent_rate)) {
-        set_error('tba', "Altitude unreachable for this configuration.");
+        set_error('target_burst_altitude', "Altitude unreachable for this configuration.");
         return;
     }
 
@@ -501,7 +501,7 @@ $(document).ready(function() {
     });
 
     // calculate result on change
-    var ids = ['mb', 'mp', 'target_ascent_rate', 'tba', 'gas', 'rho_g', 'rho_a', 'adm', 'bd', 'cd', 'bd_c', 'cd_c', 'ga'];
+    var ids = ['mb', 'mp', 'target_ascent_rate', 'target_burst_altitude', 'gas', 'rho_g', 'rho_a', 'adm', 'bd', 'cd', 'bd_c', 'cd_c', 'ga'];
 
     $('#' + ids.join(", #")).bind('keyup change',function() {
         calc_update();

--- a/js/calc.js
+++ b/js/calc.js
@@ -382,9 +382,9 @@ function calc_update() {
     document.getElementById('burst_altitude').innerHTML = burst_altitude + " m";
     document.getElementById('time_to_burst').innerHTML = time_to_burst_minutes + " min";
     document.getElementById('neck_lift').innerHTML = neck_lift_g + " g";
-    document.getElementById('lv_m3').innerHTML = launch_volume + " m<sup>3</sup>";
-    document.getElementById('lv_l').innerHTML = launch_litres + " L";
-    document.getElementById('lv_cf').innerHTML = launch_cf + " ft<sup>3</sup>";
+    document.getElementById('launch_volume_m3').innerHTML = launch_volume + " m<sup>3</sup>";
+    document.getElementById('launch_volume_l').innerHTML = launch_litres + " L";
+    document.getElementById('launch_volume_cf').innerHTML = launch_cf + " ft<sup>3</sup>";
 }
 
 var focusedElement = null;

--- a/js/calc.js
+++ b/js/calc.js
@@ -77,7 +77,7 @@ function sanity_check_inputs(mb, mp, mp_set, target_ascent_rate, target_burst_al
 
 }
 
-function sanity_check_constants(rho_gas, rho_air, adm, gravity_accel, burst_diameter, cd) {
+function sanity_check_constants(rho_gas, rho_air, adm, gravity_accel, burst_diameter, drag_coeff) {
     if(!rho_air || rho_air < 0) {
         set_error('rho_air',"You need to specify a valid air density. (0<Ad)");
         return 1;
@@ -98,8 +98,8 @@ function sanity_check_constants(rho_gas, rho_air, adm, gravity_accel, burst_diam
         set_error('gravity_accel',"You need to specify a valid gravitational acceleration. (0<Ga)");
         return 1;
     }
-    if(!cd || cd < 0 || cd > 1) {
-        set_error('cd',"You need to specify a valid drag coefficient. (0≤Cd≤1)");
+    if(!drag_coeff || drag_coeff < 0 || drag_coeff > 1) {
+        set_error('drag_coeff',"You need to specify a valid drag coefficient. (0≤Cd≤1)");
         return 1;
     }
     if(!burst_diameter || burst_diameter <= 0) {
@@ -208,66 +208,66 @@ function find_burst_diameter(mb) {
     return burst_diameter;
 }
 
-function find_cd(mb) {
-    var cds = new Array();
+function find_drag_coeff(mb) {
+    var drag_coeffs = new Array();
 
     // From Kaymont Totex Sounding Balloon Data
-    cds["k50"] = 0.25;
-    cds["k100"] = 0.25;
-    cds["k150"] = 0.25;
-    cds["k200"] = 0.25;
-    cds["k300"] = 0.25;
-    cds["k350"] = 0.25;
-    cds["k450"] = 0.25;
-    cds["k500"] = 0.25;
-    cds["k600"] = 0.30;
-    cds["k700"] = 0.30;
-    cds["k800"] = 0.30;
-    cds["k1000"] = 0.30;
-    cds["k1200"] = 0.25;
-    cds["k1500"] = 0.25;
-    cds["k1600"] = 0.25;
-    cds["k1800"] = 0.25;
-    cds["k2000"] = 0.25;
-    cds["k3000"] = 0.25;
-    cds["k4000"] = 0.25;
+    drag_coeffs["k50"] = 0.25;
+    drag_coeffs["k100"] = 0.25;
+    drag_coeffs["k150"] = 0.25;
+    drag_coeffs["k200"] = 0.25;
+    drag_coeffs["k300"] = 0.25;
+    drag_coeffs["k350"] = 0.25;
+    drag_coeffs["k450"] = 0.25;
+    drag_coeffs["k500"] = 0.25;
+    drag_coeffs["k600"] = 0.30;
+    drag_coeffs["k700"] = 0.30;
+    drag_coeffs["k800"] = 0.30;
+    drag_coeffs["k1000"] = 0.30;
+    drag_coeffs["k1200"] = 0.25;
+    drag_coeffs["k1500"] = 0.25;
+    drag_coeffs["k1600"] = 0.25;
+    drag_coeffs["k1800"] = 0.25;
+    drag_coeffs["k2000"] = 0.25;
+    drag_coeffs["k3000"] = 0.25;
+    drag_coeffs["k4000"] = 0.25;
     // Hwoyee data just guesswork
-    cds["h100"] = 0.25;
-    cds["h200"] = 0.25;
-    cds["h300"] = 0.25;
-    cds["h350"] = 0.25;
-    cds["h400"] = 0.25;
-    cds["h500"] = 0.25;
-    cds["h600"] = 0.30;
-    cds["h750"] = 0.30;
-    cds["h800"] = 0.30;
-    cds["h950"] = 0.30;
-    cds["h1000"] = 0.30;
-    cds["h1200"] = 0.25;
-    cds["h1500"] = 0.25;
-    cds["h1600"] = 0.25;
-    cds["h2000"] = 0.25;
-    cds["h3000"] = 0.25;
+    drag_coeffs["h100"] = 0.25;
+    drag_coeffs["h200"] = 0.25;
+    drag_coeffs["h300"] = 0.25;
+    drag_coeffs["h350"] = 0.25;
+    drag_coeffs["h400"] = 0.25;
+    drag_coeffs["h500"] = 0.25;
+    drag_coeffs["h600"] = 0.30;
+    drag_coeffs["h750"] = 0.30;
+    drag_coeffs["h800"] = 0.30;
+    drag_coeffs["h950"] = 0.30;
+    drag_coeffs["h1000"] = 0.30;
+    drag_coeffs["h1200"] = 0.25;
+    drag_coeffs["h1500"] = 0.25;
+    drag_coeffs["h1600"] = 0.25;
+    drag_coeffs["h2000"] = 0.25;
+    drag_coeffs["h3000"] = 0.25;
     // PAWAN data also guesswork
-    cds["p100"] = 0.25;
-    cds["p350"] = 0.25;
-    cds["p600"] = 0.3;
-    cds["p800"] = 0.3;
-    cds["p900"] = 0.3;
-    cds["p1200"] = 0.25;
-    cds["p1600"] = 0.25;
-    cds["p2000"] = 0.25;
+    drag_coeffs["p100"] = 0.25;
+    drag_coeffs["p350"] = 0.25;
+    drag_coeffs["p600"] = 0.3;
+    drag_coeffs["p800"] = 0.3;
+    drag_coeffs["p900"] = 0.3;
+    drag_coeffs["p1200"] = 0.25;
+    drag_coeffs["p1600"] = 0.25;
+    drag_coeffs["p2000"] = 0.25;
 
-    var cd;
+    var drag_coeff;
 
-    if($('#cd_c:checked').length){ 
-        cd = get_value('cd');
+    if($('#drag_coeff_c:checked').length){ 
+        drag_coeff = get_value('drag_coeff');
     } else {
-        cd = cds[$('#mb').val()];
-        // Write data back into cd field.
-        $('#cd').val(cd.toFixed(2));
+        drag_coeff = drag_coeffs[$('#mb').val()];
+        // Write data back into drag_coeff field.
+        $('#drag_coeff').val(drag_coeff.toFixed(2));
     }
-    return cd;
+    return drag_coeff;
 }
 
 function calc_update() {
@@ -299,9 +299,9 @@ function calc_update() {
     var adm = get_value('adm');
     var gravity_accel = get_value('gravity_accel');
     var burst_diameter = find_burst_diameter(mb);
-    var cd = find_cd(mb);
+    var drag_coeff = find_drag_coeff(mb);
 
-    if(sanity_check_constants(rho_gas, rho_air, adm, gravity_accel, burst_diameter, cd))
+    if(sanity_check_constants(rho_gas, rho_air, adm, gravity_accel, burst_diameter, drag_coeff))
         return;
 
     // Do some maths
@@ -322,7 +322,7 @@ function calc_update() {
         launch_radius = Math.pow((3*launch_volume)/(4*Math.PI), (1/3));
     } else if(target_ascent_rate_set) {
         var a = gravity_accel * (rho_air - rho_gas) * (4.0 / 3.0) * Math.PI;
-        var b = -0.5 * Math.pow(target_ascent_rate, 2) * cd * rho_air * Math.PI;
+        var b = -0.5 * Math.pow(target_ascent_rate, 2) * drag_coeff * rho_air * Math.PI;
         var c = 0;
         var d = - (mp + mb) * gravity_accel;
 
@@ -348,7 +348,7 @@ function calc_update() {
     neck_lift = (gross_lift - mb) * 1000;
     var total_mass = mp + mb;
     var free_lift = (gross_lift - total_mass) * gravity_accel;
-    ascent_rate = Math.sqrt(free_lift / (0.5 * cd * launch_area * rho_air));
+    ascent_rate = Math.sqrt(free_lift / (0.5 * drag_coeff * launch_area * rho_air));
     var volume_ratio = launch_volume / burst_volume;
     burst_altitude = -(adm) * Math.log(volume_ratio);
     time_to_burst = (burst_altitude / ascent_rate) / 60.0;
@@ -492,16 +492,16 @@ $(document).ready(function() {
     });
 
     // enable disabled constants
-    $('#burst_diameter_c, #cd_c').click(function() {
+    $('#burst_diameter_c, #drag_coeff_c').click(function() {
         if($('#burst_diameter_c:checked').length) $('#burst_diameter').removeAttr('disabled');
         else $('#burst_diameter').attr('disabled', 'disabled');
 
-        if($('#cd_c:checked').length) $('#cd').removeAttr('disabled');
-        else $('#cd').attr('disabled', 'disabled');
+        if($('#drag_coeff_c:checked').length) $('#drag_coeff').removeAttr('disabled');
+        else $('#drag_coeff').attr('disabled', 'disabled');
     });
 
     // calculate result on change
-    var ids = ['mb', 'mp', 'target_ascent_rate', 'target_burst_altitude', 'gas', 'rho_gas', 'rho_air', 'adm', 'burst_diameter', 'cd', 'burst_diameter_c', 'cd_c', 'gravity_accel'];
+    var ids = ['mb', 'mp', 'target_ascent_rate', 'target_burst_altitude', 'gas', 'rho_gas', 'rho_air', 'adm', 'burst_diameter', 'drag_coeff', 'burst_diameter_c', 'drag_coeff_c', 'gravity_accel'];
 
     $('#' + ids.join(", #")).bind('keyup change',function() {
         calc_update();

--- a/js/calc.js
+++ b/js/calc.js
@@ -34,22 +34,22 @@ function set_warning(id, text) {
     text = "Result (" + text + ")";
     $("#result").addClass('warning').text(text);
 }
-function sanity_check_inputs(mb, mp, mp_set, tar, tba, tar_set, tba_set) {
-    if(tar_set && tba_set) {
-        set_error('tar', "Specify either target burst altitude or target ascent rate!");
+function sanity_check_inputs(mb, mp, mp_set, target_ascent_rate, tba, target_ascent_rate_set, tba_set) {
+    if(target_ascent_rate_set && tba_set) {
+        set_error('target_ascent_rate', "Specify either target burst altitude or target ascent rate!");
         set_error('tba', "Specify either target burst altitude or target ascent rate!");
         return 1;
-    } else if(!tar_set && !tba_set) {
-        set_error('tar', "Must specify at least one target!");
+    } else if(!target_ascent_rate_set && !tba_set) {
+        set_error('target_ascent_rate', "Must specify at least one target!");
         set_error('tba', "Must specify at least one target!");
         return 1;
     }
 
-    if(tar_set && tar < 0) {
-        set_error('tar', "Target ascent rate can't be negative!");
+    if(target_ascent_rate_set && target_ascent_rate < 0) {
+        set_error('target_ascent_rate', "Target ascent rate can't be negative!");
         return 1;
-    } else if(tar_set && tar > 10) {
-        set_error('tar', "Target ascent rate is too large! (more than 10m/s)");
+    } else if(target_ascent_rate_set && target_ascent_rate > 10) {
+        set_error('target_ascent_rate', "Target ascent rate is too large! (more than 10m/s)");
         return 1;
     }
 
@@ -277,20 +277,20 @@ function calc_update() {
     // Get input values and check them
     var mb = document.getElementById('mb').value;
     var mp = get_value('mp');
-    var tar = get_value('tar');
+    var target_ascent_rate = get_value('target_ascent_rate');
     var tba = get_value('tba');
     var mp_set = 0;
-    var tar_set = 0;
+    var target_ascent_rate_set = 0;
     var tba_set = 0;
 
     if(document.getElementById('mp').value)
         mp_set = 1;
-    if(document.getElementById('tar').value)
-        tar_set = 1;
+    if(document.getElementById('target_ascent_rate').value)
+        target_ascent_rate_set = 1;
     if(document.getElementById('tba').value)
         tba_set = 1;
 
-    if(sanity_check_inputs(mb, mp, mp_set, tar, tba, tar_set, tba_set))
+    if(sanity_check_inputs(mb, mp, mp_set, target_ascent_rate, tba, target_ascent_rate_set, tba_set))
         return;
 
     // Get constants and check them
@@ -320,9 +320,9 @@ function calc_update() {
     if(tba_set) {
         launch_volume = burst_volume * Math.exp((-tba) / adm);
         launch_radius = Math.pow((3*launch_volume)/(4*Math.PI), (1/3));
-    } else if(tar_set) {
+    } else if(target_ascent_rate_set) {
         var a = ga * (rho_a - rho_g) * (4.0 / 3.0) * Math.PI;
-        var b = -0.5 * Math.pow(tar, 2) * cd * rho_a * Math.PI;
+        var b = -0.5 * Math.pow(target_ascent_rate, 2) * cd * rho_a * Math.PI;
         var c = 0;
         var d = - (mp + mb) * ga;
 
@@ -501,7 +501,7 @@ $(document).ready(function() {
     });
 
     // calculate result on change
-    var ids = ['mb', 'mp', 'tar', 'tba', 'gas', 'rho_g', 'rho_a', 'adm', 'bd', 'cd', 'bd_c', 'cd_c', 'ga'];
+    var ids = ['mb', 'mp', 'target_ascent_rate', 'tba', 'gas', 'rho_g', 'rho_a', 'adm', 'bd', 'cd', 'bd_c', 'cd_c', 'ga'];
 
     $('#' + ids.join(", #")).bind('keyup change',function() {
         calc_update();

--- a/js/calc.js
+++ b/js/calc.js
@@ -34,7 +34,7 @@ function set_warning(id, text) {
     text = "Result (" + text + ")";
     $("#result").addClass('warning').text(text);
 }
-function sanity_check_inputs(mb, mp, mp_set, target_ascent_rate, target_burst_altitude, target_ascent_rate_set, target_burst_altitude_set) {
+function sanity_check_inputs(mb, payload_mass_g, payload_mass_set, target_ascent_rate, target_burst_altitude, target_ascent_rate_set, target_burst_altitude_set) {
     if(target_ascent_rate_set && target_burst_altitude_set) {
         set_error('target_ascent_rate', "Specify either target burst altitude or target ascent rate!");
         set_error('target_burst_altitude', "Specify either target burst altitude or target ascent rate!");
@@ -62,14 +62,14 @@ function sanity_check_inputs(mb, mp, mp_set, target_ascent_rate, target_burst_al
         return 1;
     }
 
-    if(!mp_set) {
-        set_error('mp', "You have to enter a payload mass!");
+    if(!payload_mass_set) {
+        set_error('payload_mass_g', "You have to enter a payload mass!");
         return 1;
-    } else if(mp < 10) {
-        set_error('mp', "Mass is too small! (less than 10g)");
+    } else if(payload_mass_g < 10) {
+        set_error('payload_mass_g', "Mass is too small! (less than 10g)");
         return 1;
-    } else if(mp > 20000) {
-        set_error('mp', "Mass is too large! (over 20kg)");
+    } else if(payload_mass_g > 20000) {
+        set_error('payload_mass_g', "Mass is too large! (over 20kg)");
         return 1;
     }
 
@@ -276,21 +276,21 @@ function calc_update() {
 
     // Get input values and check them
     var mb = document.getElementById('mb').value;
-    var mp = get_value('mp');
+    var payload_mass_g = get_value('payload_mass_g');
     var target_ascent_rate = get_value('target_ascent_rate');
     var target_burst_altitude = get_value('target_burst_altitude');
-    var mp_set = 0;
+    var payload_mass_set = 0;
     var target_ascent_rate_set = 0;
     var target_burst_altitude_set = 0;
 
-    if(document.getElementById('mp').value)
-        mp_set = 1;
+    if(document.getElementById('payload_mass_g').value)
+        payload_mass_set = 1;
     if(document.getElementById('target_ascent_rate').value)
         target_ascent_rate_set = 1;
     if(document.getElementById('target_burst_altitude').value)
         target_burst_altitude_set = 1;
 
-    if(sanity_check_inputs(mb, mp, mp_set, target_ascent_rate, target_burst_altitude, target_ascent_rate_set, target_burst_altitude_set))
+    if(sanity_check_inputs(mb, payload_mass_g, payload_mass_set, target_ascent_rate, target_burst_altitude, target_ascent_rate_set, target_burst_altitude_set))
         return;
 
     // Get constants and check them
@@ -306,7 +306,7 @@ function calc_update() {
 
     // Do some maths
     mb = parseFloat(mb.substr(1)) / 1000.0;
-    mp = mp / 1000.0;
+    payload_mass = payload_mass_g / 1000.0;
 
     var ascent_rate = 0;
     var burst_altitude = 0;
@@ -324,7 +324,7 @@ function calc_update() {
         var a = gravity_accel * (rho_air - rho_gas) * (4.0 / 3.0) * Math.PI;
         var b = -0.5 * Math.pow(target_ascent_rate, 2) * drag_coeff * rho_air * Math.PI;
         var c = 0;
-        var d = - (mp + mb) * gravity_accel;
+        var d = - (payload_mass + mb) * gravity_accel;
 
         var f = (((3*c)/a) - (Math.pow(b, 2) / Math.pow(a,2)) / 3.0);
         var g = (((2*Math.pow(b,3))/Math.pow(a,3)) -
@@ -346,7 +346,7 @@ function calc_update() {
     var density_difference = rho_air - rho_gas;
     var gross_lift = launch_volume * density_difference;
     neck_lift = (gross_lift - mb) * 1000;
-    var total_mass = mp + mb;
+    var total_mass = payload_mass + mb;
     var free_lift = (gross_lift - total_mass) * gravity_accel;
     ascent_rate = Math.sqrt(free_lift / (0.5 * drag_coeff * launch_area * rho_air));
     var volume_ratio = launch_volume / burst_volume;
@@ -358,7 +358,7 @@ function calc_update() {
         return;
     }
 
-    if(mp > 3.0) {
+    if(payload_mass > 3.0) {
         set_warning('regulatory', "Payload mass may exceed 'heavy package' limits - please check you are compliance with your local regulations!");
     }
 
@@ -501,7 +501,7 @@ $(document).ready(function() {
     });
 
     // calculate result on change
-    var ids = ['mb', 'mp', 'target_ascent_rate', 'target_burst_altitude', 'gas', 'rho_gas', 'rho_air', 'adm', 'burst_diameter', 'drag_coeff', 'burst_diameter_c', 'drag_coeff_c', 'gravity_accel'];
+    var ids = ['mb', 'payload_mass_g', 'target_ascent_rate', 'target_burst_altitude', 'gas', 'rho_gas', 'rho_air', 'adm', 'burst_diameter', 'drag_coeff', 'burst_diameter_c', 'drag_coeff_c', 'gravity_accel'];
 
     $('#' + ids.join(", #")).bind('keyup change',function() {
         calc_update();

--- a/js/calc.js
+++ b/js/calc.js
@@ -77,16 +77,16 @@ function sanity_check_inputs(mb, mp, mp_set, target_ascent_rate, target_burst_al
 
 }
 
-function sanity_check_constants(rho_g, rho_a, adm, ga, burst_diameter, cd) {
-    if(!rho_a || rho_a < 0) {
-        set_error('rho_a',"You need to specify a valid air density. (0<Ad)");
+function sanity_check_constants(rho_g, rho_air, adm, ga, burst_diameter, cd) {
+    if(!rho_air || rho_air < 0) {
+        set_error('rho_air',"You need to specify a valid air density. (0<Ad)");
         return 1;
     }
     if(!rho_g || rho_g < 0) {
         set_error('rho_g',"You need to specify a valid gas density. (0<Gd)");
         return 1;
     }
-    if(rho_g > rho_a) {
+    if(rho_g > rho_air) {
         set_error('rho_g',"Air density is less the gas density.");
         return 1;
     }
@@ -295,13 +295,13 @@ function calc_update() {
 
     // Get constants and check them
     var rho_g = find_rho_g();
-    var rho_a = get_value('rho_a');
+    var rho_air = get_value('rho_air');
     var adm = get_value('adm');
     var ga = get_value('ga');
     var burst_diameter = find_burst_diameter(mb);
     var cd = find_cd(mb);
 
-    if(sanity_check_constants(rho_g, rho_a, adm, ga, burst_diameter, cd))
+    if(sanity_check_constants(rho_g, rho_air, adm, ga, burst_diameter, cd))
         return;
 
     // Do some maths
@@ -321,8 +321,8 @@ function calc_update() {
         launch_volume = burst_volume * Math.exp((-target_burst_altitude) / adm);
         launch_radius = Math.pow((3*launch_volume)/(4*Math.PI), (1/3));
     } else if(target_ascent_rate_set) {
-        var a = ga * (rho_a - rho_g) * (4.0 / 3.0) * Math.PI;
-        var b = -0.5 * Math.pow(target_ascent_rate, 2) * cd * rho_a * Math.PI;
+        var a = ga * (rho_air - rho_g) * (4.0 / 3.0) * Math.PI;
+        var b = -0.5 * Math.pow(target_ascent_rate, 2) * cd * rho_air * Math.PI;
         var c = 0;
         var d = - (mp + mb) * ga;
 
@@ -343,12 +343,12 @@ function calc_update() {
 
     var launch_area = Math.PI * Math.pow(launch_radius, 2);
     var launch_volume = (4.0/3.0) * Math.PI * Math.pow(launch_radius, 3);
-    var density_difference = rho_a - rho_g;
+    var density_difference = rho_air - rho_g;
     var gross_lift = launch_volume * density_difference;
     neck_lift = (gross_lift - mb) * 1000;
     var total_mass = mp + mb;
     var free_lift = (gross_lift - total_mass) * ga;
-    ascent_rate = Math.sqrt(free_lift / (0.5 * cd * launch_area * rho_a));
+    ascent_rate = Math.sqrt(free_lift / (0.5 * cd * launch_area * rho_air));
     var volume_ratio = launch_volume / burst_volume;
     burst_altitude = -(adm) * Math.log(volume_ratio);
     time_to_burst = (burst_altitude / ascent_rate) / 60.0;
@@ -501,7 +501,7 @@ $(document).ready(function() {
     });
 
     // calculate result on change
-    var ids = ['mb', 'mp', 'target_ascent_rate', 'target_burst_altitude', 'gas', 'rho_g', 'rho_a', 'adm', 'burst_diameter', 'cd', 'burst_diameter_c', 'cd_c', 'ga'];
+    var ids = ['mb', 'mp', 'target_ascent_rate', 'target_burst_altitude', 'gas', 'rho_g', 'rho_air', 'adm', 'burst_diameter', 'cd', 'burst_diameter_c', 'cd_c', 'ga'];
 
     $('#' + ids.join(", #")).bind('keyup change',function() {
         calc_update();

--- a/js/calc.js
+++ b/js/calc.js
@@ -34,7 +34,7 @@ function set_warning(id, text) {
     text = "Result (" + text + ")";
     $("#result").addClass('warning').text(text);
 }
-function sanity_check_inputs(mb, payload_mass_g, payload_mass_set, target_ascent_rate, target_burst_altitude, target_ascent_rate_set, target_burst_altitude_set) {
+function sanity_check_inputs(balloon_model, payload_mass_g, payload_mass_set, target_ascent_rate, target_burst_altitude, target_ascent_rate_set, target_burst_altitude_set) {
     if(target_ascent_rate_set && target_burst_altitude_set) {
         set_error('target_ascent_rate', "Specify either target burst altitude or target ascent rate!");
         set_error('target_burst_altitude', "Specify either target burst altitude or target ascent rate!");
@@ -144,7 +144,7 @@ function find_rho_gas() {
     return rho_gas;
 }
 
-function find_burst_diameter(mb) {
+function find_burst_diameter(balloon_model) {
     var burst_diameters = new Array();
 
     // From Kaymont Totex Sounding Balloon Data
@@ -200,7 +200,7 @@ function find_burst_diameter(mb) {
     if($('#burst_diameter_c:checked').length){
         burst_diameter = get_value('burst_diameter');
     } else {
-        burst_diameter = burst_diameters[$('#mb').val()];
+        burst_diameter = burst_diameters[$('#balloon_model').val()];
         // Write data back into burst_diameter field.
         $('#burst_diameter').val(burst_diameter.toFixed(2));
     }
@@ -208,7 +208,7 @@ function find_burst_diameter(mb) {
     return burst_diameter;
 }
 
-function find_drag_coeff(mb) {
+function find_drag_coeff(balloon_model) {
     var drag_coeffs = new Array();
 
     // From Kaymont Totex Sounding Balloon Data
@@ -263,7 +263,7 @@ function find_drag_coeff(mb) {
     if($('#drag_coeff_c:checked').length){ 
         drag_coeff = get_value('drag_coeff');
     } else {
-        drag_coeff = drag_coeffs[$('#mb').val()];
+        drag_coeff = drag_coeffs[$('#balloon_model').val()];
         // Write data back into drag_coeff field.
         $('#drag_coeff').val(drag_coeff.toFixed(2));
     }
@@ -275,7 +275,7 @@ function calc_update() {
     clear_errors();
 
     // Get input values and check them
-    var mb = document.getElementById('mb').value;
+    var balloon_model = document.getElementById('balloon_model').value;
     var payload_mass_g = get_value('payload_mass_g');
     var target_ascent_rate = get_value('target_ascent_rate');
     var target_burst_altitude = get_value('target_burst_altitude');
@@ -290,7 +290,7 @@ function calc_update() {
     if(document.getElementById('target_burst_altitude').value)
         target_burst_altitude_set = 1;
 
-    if(sanity_check_inputs(mb, payload_mass_g, payload_mass_set, target_ascent_rate, target_burst_altitude, target_ascent_rate_set, target_burst_altitude_set))
+    if(sanity_check_inputs(balloon_model, payload_mass_g, payload_mass_set, target_ascent_rate, target_burst_altitude, target_ascent_rate_set, target_burst_altitude_set))
         return;
 
     // Get constants and check them
@@ -298,14 +298,15 @@ function calc_update() {
     var rho_air = get_value('rho_air');
     var adm = get_value('adm');
     var gravity_accel = get_value('gravity_accel');
-    var burst_diameter = find_burst_diameter(mb);
-    var drag_coeff = find_drag_coeff(mb);
+    var burst_diameter = find_burst_diameter(balloon_model);
+    var drag_coeff = find_drag_coeff(balloon_model);
 
     if(sanity_check_constants(rho_gas, rho_air, adm, gravity_accel, burst_diameter, drag_coeff))
         return;
 
     // Do some maths
-    mb = parseFloat(mb.substr(1)) / 1000.0;
+    // model name is one letter prefix then integer string in grams
+    balloon_mass = parseFloat(balloon_model.substr(1)) / 1000.0;
     payload_mass = payload_mass_g / 1000.0;
 
     var ascent_rate = 0;
@@ -324,7 +325,7 @@ function calc_update() {
         var a = gravity_accel * (rho_air - rho_gas) * (4.0 / 3.0) * Math.PI;
         var b = -0.5 * Math.pow(target_ascent_rate, 2) * drag_coeff * rho_air * Math.PI;
         var c = 0;
-        var d = - (payload_mass + mb) * gravity_accel;
+        var d = - (payload_mass + balloon_mass) * gravity_accel;
 
         var f = (((3*c)/a) - (Math.pow(b, 2) / Math.pow(a,2)) / 3.0);
         var g = (((2*Math.pow(b,3))/Math.pow(a,3)) -
@@ -345,8 +346,8 @@ function calc_update() {
     var launch_volume = (4.0/3.0) * Math.PI * Math.pow(launch_radius, 3);
     var density_difference = rho_air - rho_gas;
     var gross_lift = launch_volume * density_difference;
-    neck_lift = (gross_lift - mb) * 1000;
-    var total_mass = payload_mass + mb;
+    neck_lift = (gross_lift - balloon_mass) * 1000;
+    var total_mass = payload_mass + balloon_mass;
     var free_lift = (gross_lift - total_mass) * gravity_accel;
     ascent_rate = Math.sqrt(free_lift / (0.5 * drag_coeff * launch_area * rho_air));
     var volume_ratio = launch_volume / burst_volume;
@@ -501,7 +502,7 @@ $(document).ready(function() {
     });
 
     // calculate result on change
-    var ids = ['mb', 'payload_mass_g', 'target_ascent_rate', 'target_burst_altitude', 'gas', 'rho_gas', 'rho_air', 'adm', 'burst_diameter', 'drag_coeff', 'burst_diameter_c', 'drag_coeff_c', 'gravity_accel'];
+    var ids = ['balloon_model', 'payload_mass_g', 'target_ascent_rate', 'target_burst_altitude', 'gas', 'rho_gas', 'rho_air', 'adm', 'burst_diameter', 'drag_coeff', 'burst_diameter_c', 'drag_coeff_c', 'gravity_accel'];
 
     $('#' + ids.join(", #")).bind('keyup change',function() {
         calc_update();


### PR DESCRIPTION
As part of studying how the altitude predictor works and comparing to the original `burst1a.xls` it was useful to rename the variables to be more descriptive.

Commits in the series handle one variable name at a time, sometimes splitting calc/display and adding suffixes to indicate the implied units.

No changes in the algorithm.