### PR TITLE
New default parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,8 +74,8 @@
             <p>
                 Usage is very straightforward: enter the payload mass into the first box, select the balloon
                 mass from the second box, and type in either a desired burst altitude in meters or ascent rate
-                in meters per second in the relevent box. Pressing enter or clicking away from the box you are
-                typing into will run the calculations, displaying the results in the box at the bottom.
+                in meters per second in the relevent box. We generally recommend targeting an ascent rate of 5m/s rather than trying to to target a particular burst altitude.
+                Pressing enter or clicking away from the box you are typing into will run the calculations, displaying the results in the box at the bottom.
             </p>
             <p>
                 The 'Constants' box can be used to adjust constants used by the calculator. These include
@@ -100,6 +100,9 @@
                 balloon parameters.
             </p>
             <p>
+                Please contact <a href="mailto:support@sondehub.org">support@sondehub.org</a> with any queries about this calculator.
+            </p>
+            <p>
                 The HTML and javascript was written by Adam Greig (<a href="http://www.cusf.co.uk">CUSF</a>)
                 and Rossen Georgiev; the first version in 2010 and a rewrite in 2012. This code is licensed
                 under the GPL (v3); see below. <br>
@@ -109,7 +112,6 @@
                 by Adam. <br>
                 It also contains Balloon information from Kaymont Totex sounding balloon data and Hwoyee. <br>
                 Some additional modifications by Mark Jessop. <br>
-                Last updated: 2023-09-13, Added additional Kaymont balloon data.
             </p>
             <p>
                 No guarantee is given for the accuracy of any data included or produced by this program, use
@@ -125,7 +127,7 @@
                 <div class="five columns alpha grey float first">
                     <div class="sign"></div>
                     <h4>Payload Mass (g)</h4>
-                    <input type="text" id="mp" class="input_field numeric scrollable" value="1500" data-step="5" tabindex="1"/>
+                    <input type="text" id="mp" class="input_field numeric scrollable" value="1000" data-step="5" tabindex="1"/>
                     <h4>Balloon Mass (g)</h4>
                     <select class="input_field" id="mb" tabindex="2">
                         <option value="k100">Kaymont - 100</option>
@@ -135,7 +137,7 @@
                         <option value="k350">Kaymont - 350</option>
                         <option value="k600">Kaymont - 600</option>
                         <option value="k800">Kaymont - 800</option>
-                        <option value="k1000" selected="selected">Kaymont - 1000</option>
+                        <option value="k1000">Kaymont - 1000</option>
                         <option value="k1200">Kaymont - 1200</option>
                         <option value="k1500">Kaymont - 1500</option>
                         <option value="k1600">Kaymont - 1600</option>
@@ -151,7 +153,7 @@
                         <option value="h600">Hwoyee - 600</option>
                         <option value="h750">Hwoyee - 750</option>
                         <option value="h800">Hwoyee - 800</option>
-                        <option value="h1000">Hwoyee - 1000</option>
+                        <option value="h1000" selected="selected">Hwoyee - 1000</option>
                         <option value="h1200">Hwoyee - 1200</option>
                         <option value="h1600">Hwoyee - 1600</option>
                         <option value="h2000">Hwoyee - 2000</option>
@@ -169,9 +171,9 @@
                 <div class="five columns alpha grey float second">
                     <div class="sign"></div>
                     <h4>Target Burst Altitude (m)</h4>
-                    <input type="text" id="tba" class="input_field numeric scrollable" data-step="100" value="33000" tabindex="3"/>
+                    <input type="text" id="tba" class="input_field numeric scrollable" data-step="100" tabindex="3"/>
                     <h4>Target Ascent rate (m/s)</h4>
-                    <input type="text" id="tar" class="input_field numeric scrollable" data-step="0.1" tabindex="4"/>
+                    <input type="text" id="tar" class="input_field numeric scrollable" data-step="0.1" value="5.0" tabindex="4"/>
                 </div>
                 <div class="thirteen columns alpha grey third">
                     <h4 id="result">Result</h4>

--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
                         <option value="k350">Kaymont - 350</option>
                         <option value="k600">Kaymont - 600</option>
                         <option value="k800">Kaymont - 800</option>
-                        <option value="k1000">Kaymont - 1000</option>
+                        <option value="k1000" selected="selected">Kaymont - 1000</option>
                         <option value="k1200">Kaymont - 1200</option>
                         <option value="k1500">Kaymont - 1500</option>
                         <option value="k1600">Kaymont - 1600</option>
@@ -153,7 +153,7 @@
                         <option value="h600">Hwoyee - 600</option>
                         <option value="h750">Hwoyee - 750</option>
                         <option value="h800">Hwoyee - 800</option>
-                        <option value="h1000" selected="selected">Hwoyee - 1000</option>
+                        <option value="h1000">Hwoyee - 1000</option>
                         <option value="h1200">Hwoyee - 1200</option>
                         <option value="h1600">Hwoyee - 1600</option>
                         <option value="h2000">Hwoyee - 2000</option>

--- a/js/calc.js
+++ b/js/calc.js
@@ -358,9 +358,15 @@ function calc_update() {
         return;
     }
 
-    if(bd >= 10 && ascent_rate < 4.8) {
-        set_warning('floater', "configuration suggests a possible floater");
+    if(mp > 3.0) {
+        set_warning('regulatory', "Payload mass may exceed 'heavy package' limits - please check you are compliance with your local regulations!");
     }
+
+    // Note - this warning will override the regulatory warning above.
+    if(bd >= 10 && ascent_rate < 4.8) {
+        set_warning('floater', "Configuration suggests a possible floater");
+    }
+
 
     ascent_rate = ascent_rate.toFixed(2);
     burst_altitude = burst_altitude.toFixed();


### PR DESCRIPTION
Changed some default parameters:
* Payload mass changed to 1000g
* Change default target to 5m/s ascent rate. It's generally better to target a nominal ascent rate rather than a burst altitude.

Added a warning if the payload mass is >3000g, to indicate the launch may include payloads that are above the individual payload mass limit.